### PR TITLE
Prevents AppNap when connected to switcher

### DIFF
--- a/atemOSC/SwitcherPanelAppDelegate.h
+++ b/atemOSC/SwitcherPanelAppDelegate.h
@@ -87,6 +87,7 @@ class InputMonitor;
 }
 
 @property (assign) IBOutlet NSWindow *window;
+@property (strong) id activity;
 
 - (IBAction)connectButtonPressed:(id)sender;
 - (IBAction)portChanged:(id)sender;

--- a/atemOSC/SwitcherPanelAppDelegate.mm
+++ b/atemOSC/SwitcherPanelAppDelegate.mm
@@ -605,7 +605,7 @@ private:
 	IBMDSwitcherInputIterator* inputIterator = NULL;
     
     if ([[NSProcessInfo processInfo] respondsToSelector:@selector(beginActivityWithOptions:reason:)]) {
-        [[NSProcessInfo processInfo] beginActivityWithOptions:0x00FFFFFF reason:@"receiving OSC messages"];
+        self.activity = [[NSProcessInfo processInfo] beginActivityWithOptions:0x00FFFFFF reason:@"receiving OSC messages"];
     }
     
     OSCMessage *newMsg = [OSCMessage createWithAddress:@"/atem/led/green"];
@@ -711,7 +711,12 @@ finish:
 
 - (void)switcherDisconnected
 {
-	
+	if (self.activity) {
+        [[NSProcessInfo processInfo] endActivity:self.activity];
+    }
+    
+    self.activity = nil;
+    
     OSCMessage *newMsg = [OSCMessage createWithAddress:@"/atem/led/green"];
     [newMsg addFloat:0.0];
     [outPort sendThisMessage:newMsg];


### PR DESCRIPTION
activity needs to be stored in property for options to be applied
