### PR TITLE
added version 2.3.4 with more control over dsk and transition styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# atemOSC v2.3.3
+# atemOSC v2.3.4
+
+## Changelog v2.3.4
+- added support for specifying transition style
+- added more control over downstream keyer states
 
 ## Changelog v2.3.3
 - added support for controlling Media Players
@@ -66,11 +70,21 @@ For preview selection `/atem/preview/$i` can be used.
  - **auto** `/atem/transition/auto`
  - **fade-to-black** `/atem/transition/ftb`
 
+To set the transition style of the Auto transition:
+
+ - **Mix** `/atem/transition/set-style/mix`
+ - **Dip** `/atem/transition/set-style/dip`
+ - **Wipe** `/atem/transition/set-style/wipe`
+ - **Stinger** `/atem/transition/set-style/sting`
+ - **DVE** `/atem/transition/set-style/dve`
+
 Additional options.
 
  - **Toggle Upstream Keyer 1** `/atem/usk/1` (up to `/atem/usk/4`, depends on your ATEM switcher)
  - **Prepare Upstream Keyer 1** `/atem/nextusk/1`  (up to `/atem/nextusk/4`, depends on your ATEM switcher)
- - **Toggle Downstreamkeyer 1** `/atem/dsk/1` (up to `/atem/dsk/4`, depends on your ATEM switcher)
+ - **Auto Toggle Downstreamkeyer 1** `/atem/dsk/1` (up to `/atem/dsk/4`, depends on your ATEM switcher)
+ - **Tie Downstreamkeyer 1** `/atem/dsk/tie/1` (up to `/atem/dsk/tie/4`, depends on your ATEM switcher)
+ - **Cut Toggle Downstreamkeyer 1** `/atem/dsk/toggle/1` (up to `/atem/dsk/toggle/4`, depends on your ATEM switcher)
  - **Set Media Player $i source to Clip $x** `/atem/mplayer/$i/clip/$x`
    - e.g. `/atem/mplayer/1/clip/1` ()up to `/atem/mplayer/1/clip/2`, depends on your ATEM switcher
    - e.g. `/atem/mplayer/2/clip/1` (up to `/atem/mplayer/2/clip/2`, depends on your ATEM switcher)

--- a/atemOSC/atemOSC-Info.plist
+++ b/atemOSC/atemOSC-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.3</string>
+	<string>2.3.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
added new `/atem/transition/set-style` calls
added new `/atem/dsk` calls

Note that I don't actually like how the `/atem/dsk` calls are laid out currently, but I didn't want to change the existing `/atem/dsk/1` calls in case you were using them. Feel free to clean up those addresses.
