### PR TITLE
Issue #30 - New API Command: Set Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,18 @@ Additional options.
    - (up to `/atem/aux/6 $x`, depends on your ATEM switcher)
  - **Toggle Upstream Keyer 1** `/atem/usk/1` (up to `/atem/usk/4`, depends on your ATEM switcher)
  - **Prepare Upstream Keyer 1** `/atem/nextusk/1`  (up to `/atem/nextusk/4`, depends on your ATEM switcher)
+ - **Set Upstream Keyer 1 for Next Scene** `/atem/set-nextusk/1 <0|1>` (up to `/atem/set-nextusk/4`, depends on your ATEM switcher)
+     - Where `<0|1>` is an int-value of 0 (don't show USK after next transition) or 1 (show USK after next transition)
+     - e.g. If USK1 is on air, `/atem/set-nextusk/1 1` will untie USK1 so that it remains on, while `/atem/set-nextusk/1 0` will tie USK1 so that it will go off air after the next transition.
  - **Auto Toggle On Air Downstreamkeyer 1** `/atem/dsk/1` (up to `/atem/dsk/4`, depends on your ATEM switcher)
  - **Force On Air Downstreamkeyer 1** `/atem/dsk/on-air/1	<0|1>` (up to `/atem/dsk/4`, depends on your ATEM switcher)
      - Where `<0|1>` is an int-value of 0 (disabled) or 1 (enabled)
  - **Toggle Tie Downstreamkeyer 1** `/atem/dsk/tie/1` (up to `/atem/dsk/tie/4`, depends on your ATEM switcher)
  - **Force Tie Downstreamkeyer 1** `/atem/dsk/set-tie/1	<0|1>` (up to `/atem/dsk/4`, depends on your ATEM switcher)
      - Where `<0|1>` is an int-value of 0 (disabled) or 1 (enabled)
+ - **Set Downstreamkeyer 1 for Next Scene** `/atem/dsk/set-next/1 <0|1>` (up to `/atem/dsk/set-next/4`, depends on your ATEM switcher)
+     - Where `<0|1>` is an int-value of 0 (don't show DSK after next transition) or 1 (show DSK after next transition)
+     - e.g. If DSK1 is on air, `/atem/dsk/set-next/1 1` will untie DSK1 so that it remains on, while `/atem/dsk/set-next/1 0` will tie DSK1 so that it will go off air after the next transition.
  - **Cut Toggle Downstreamkeyer 1** `/atem/dsk/toggle/1` (up to `/atem/dsk/toggle/4`, depends on your ATEM switcher)
  - **Set Media Player $i source to Clip $x** `/atem/mplayer/$i/clip/$x`
    - e.g. `/atem/mplayer/1/clip/1` (up to `/atem/mplayer/1/clip/2`, depends on your ATEM switcher)

--- a/atemOSC/SwitcherPanelAppDelegate.mm
+++ b/atemOSC/SwitcherPanelAppDelegate.mm
@@ -373,6 +373,32 @@ private:
                 }
             }
         } else if ([[address objectAtIndex:1] isEqualToString:@"atem"] &&
+                   [[address objectAtIndex:2] isEqualToString:@"set-nextusk"]) {
+            int t = [[address objectAtIndex:3] intValue];
+            bool value = [[m value] floatValue] != 0.0;
+            uint32_t currentTransitionSelection;
+            switcherTransitionParameters->GetNextTransitionSelection(&currentTransitionSelection);
+            
+            uint32_t transitionSelections[5] = { bmdSwitcherTransitionSelectionBackground, bmdSwitcherTransitionSelectionKey1, bmdSwitcherTransitionSelectionKey2, bmdSwitcherTransitionSelectionKey3, bmdSwitcherTransitionSelectionKey4 };
+            uint32_t requestedTransitionSelection = transitionSelections[t];
+            
+            std::list<IBMDSwitcherKey*>::iterator iter = keyers.begin();
+            std::advance(iter, t-1);
+            IBMDSwitcherKey * key = *iter;
+            bool isOnAir;
+            key->GetOnAir(&isOnAir);
+            
+            if (value != isOnAir) {
+                switcherTransitionParameters->SetNextTransitionSelection(currentTransitionSelection | requestedTransitionSelection);
+            } else {
+                
+                // If we are attempting to deselect the only bit set, then default to setting TransitionSelectionBackground
+                if ((currentTransitionSelection & ~requestedTransitionSelection) == 0)
+                    switcherTransitionParameters->SetNextTransitionSelection(bmdSwitcherTransitionSelectionBackground);
+                else
+                    switcherTransitionParameters->SetNextTransitionSelection(currentTransitionSelection & ~requestedTransitionSelection);
+            }
+		} else if ([[address objectAtIndex:1] isEqualToString:@"atem"] &&
                    [[address objectAtIndex:2] isEqualToString:@"nextusk"]) {
             switch ([[address objectAtIndex:3] intValue]) {
                 case 0:

--- a/atemOSC/SwitcherPanelAppDelegate.mm
+++ b/atemOSC/SwitcherPanelAppDelegate.mm
@@ -468,6 +468,22 @@ private:
                     key->IsTransitioning(&isTransitioning);
                     if (!isTransitioning) key->SetOnAir(value);
                 }
+			} else if ([[address objectAtIndex:3] isEqualToString:@"set-next"])
+            {
+                int t = [[address objectAtIndex:4] intValue];
+                bool value = [[m value] floatValue] != 0.0;
+                
+                if (t<=dsk.size()) {
+                    
+                    std::list<IBMDSwitcherDownstreamKey*>::iterator iter = dsk.begin();
+                    std::advance(iter, t-1);
+                    IBMDSwitcherDownstreamKey * key = *iter;
+                    
+                    bool isTransitioning, isOnAir;
+                    key->IsTransitioning(&isTransitioning);
+					key->GetOnAir(&isOnAir);
+                    if (!isTransitioning) key->SetTie(value != isOnAir);
+                }
             } else {
                 int t = [[address objectAtIndex:3] intValue];
                 


### PR DESCRIPTION
### Purpose

This PR adds two new commands: /atem/dsk/set-next and /atem/set-nextusk.  They serve the same purpose for the DSK and USK, respectively.

Here is their basic function:
If I know I want a key to be on air after the next transition, and don't want to worry about the current state of the system, I call set-next on the key and AtemOSC will tie or untie as necessary to make sure that it is on air after the next transition. This also works if you know you want something to be off air.

### Use Case

The use case I am using it for is in a queuing system, where for each queue I specify what keys I want on, but I want to be able to transition from any queue to any other queue, so I basically tell the system "Do what you need to do to make sure these keyers are active when this queue happens." 

I believe this feature can find many other uses as well.

### Documentation

The one thing I am unsure about is how to document this feature concisely, I put my best effort into updating the README but am not confident that it is the best way to label or present this feature.  Once we can discuss this wording, I will put it into the in-app documentation as well before this is pushed in.

### Testing

This was tested on an ATEM production switcher using TouchOSC, but please test it yourself to make sure I didn't miss anything.

### Conclusion

See Issue #30 for the origin of this idea.

Let me know what you think and if there are any changes requested in regards to how I implemented this feature.