### PR TITLE
Bug Fix - Not handling float values correctly when converting to bool

### DIFF
--- a/atemOSC/SwitcherPanelAppDelegate.mm
+++ b/atemOSC/SwitcherPanelAppDelegate.mm
@@ -409,7 +409,7 @@ private:
             if ([[address objectAtIndex:3] isEqualToString:@"set-tie"])
             {
                 int t = [[address objectAtIndex:4] intValue];
-                bool value = [[m value] boolValue];
+                bool value = [[m value] floatValue] != 0.0;
                 
                 if (t<=dsk.size()) {
                     
@@ -456,7 +456,7 @@ private:
             } else if ([[address objectAtIndex:3] isEqualToString:@"on-air"])
             {
                 int t = [[address objectAtIndex:4] intValue];
-                bool value = [[m value] boolValue];
+                bool value = [[m value] floatValue] != 0.0;
                 
                 if (t<=dsk.size()) {
                     
@@ -639,7 +639,7 @@ private:
     box = box-1;
     
     if ([[address objectAtIndex:5] isEqualToString:@"enabled"]) {
-        bool value = [[m value] boolValue];
+        bool value = [[m value] floatValue] != 0.0;
         mSuperSourceBoxes[box]->SetEnabled(value);
     } else if ([[address objectAtIndex:5] isEqualToString:@"source"]) {
         int value = [[m value] intValue];
@@ -655,7 +655,7 @@ private:
         float value = [[m value] floatValue];
         mSuperSourceBoxes[box]->SetSize(value);
     } else if ([[address objectAtIndex:5] isEqualToString:@"cropped"]) {
-        bool value = [[m value] boolValue];
+        bool value = [[m value] floatValue] != 0.0;
         mSuperSourceBoxes[box]->SetCropped(value);
     } else if ([[address objectAtIndex:5] isEqualToString:@"crop-top"]) {
         float value = [[m value] floatValue];


### PR DESCRIPTION
I found that when sending float values (specifically from TouchOSC, which only sends floats), the value 0.000 and 1.000 were both being converted to false by boolValue.  By changing the remaining calls to use a float value comparison with 0.0, it should be able to handle input more consistently.  I noticed that this convention (comparing a float to 0.0) was used elsewhere in the code, so hopefully the changes here make sense.