### PR TITLE
Bug Fix - Crash because log was being updated from a background thread

### DIFF
--- a/atemOSC/SwitcherPanelAppDelegate.mm
+++ b/atemOSC/SwitcherPanelAppDelegate.mm
@@ -1441,7 +1441,9 @@ finish:
 - (void)logMessage:(NSString *)message
 {
     if (message) {
-        [self appendMessage:message];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self appendMessage:message];
+        });
         NSLog(@"%@", message);
     }
 }


### PR DESCRIPTION
I found that AtemOSC was consistently crashing when I opened up the log panel from the help menu, and tracked the crash down to the fact that sometimes the logging was happening from the background thread.  For safety, this change forces all logging to the UI to be done on the main thread, and fixed the crash I was having.