### PR TITLE
Issue #13/#17 - Adding DSK & USK monitoring and feedback

### DIFF
--- a/atemOSC/SwitcherPanelAppDelegate.h
+++ b/atemOSC/SwitcherPanelAppDelegate.h
@@ -35,6 +35,8 @@
 
 class MixEffectBlockMonitor;
 class SwitcherMonitor;
+class DownstreamKeyerMonitor;
+class TransitionParametersMonitor;
 class InputMonitor;
 
 @interface SwitcherPanelAppDelegate : NSObject <NSApplicationDelegate, OSCDelegateProtocol, NSTextFieldDelegate>
@@ -52,6 +54,8 @@ class InputMonitor;
     IBMDSwitcherTransitionParameters* switcherTransitionParameters;
     IBMDSwitcherKeyFlyParameters*	mDVEControl;
 	SwitcherMonitor*			mSwitcherMonitor;
+    DownstreamKeyerMonitor*     mDownstreamKeyerMonitor;
+    TransitionParametersMonitor*    mTransitionParametersMonitor;
 	IBMDSwitcherMediaPool*		mMediaPool;
     IBMDSwitcherStills*			mStills;
     IBMDSwitcherInputSuperSource*   mSuperSource;
@@ -118,6 +122,9 @@ class InputMonitor;
 - (void)updateTransitionFramesTextField;
 - (void)updateFTBFramesTextField;
 - (void)mixEffectBlockBoxSetEnabled:(bool)enabled;
+- (void)updateUSKTie;
+- (void)updateDSKOnAir;
+- (void)updateDSKTie;
 
 
 // Serial Port Methods


### PR DESCRIPTION
### Purpose

This PR addresses a common issue where the DSK and USK don't update in a TouchOSC layout (or other software) when they are changed on the switcher using the stem control software or with Strata Pro.  This is resolved by listening for DSK/USK changes and sending OSC signals containing the current state of each USK and DSK.

This addresses concerns brought up in Issues #13 and #17.

### Consolidation

In the process of creating two new monitors to handle this, DownstreamKeyerMonitor and TransitionParameterMonitor, I noticed that there was a lot of unecessary duplicate code in the existing Monitor classes, so I moved this repeated code to a GenericMonitor class and made the existing Monitor classes inherit from this.  This makes the codebase much more concise and allows for easily adding more monitors in the future.

### Concession 

I'll admit that the way git diff presented these changes really messes with what actually changed, so for the changes in the beginning of atemOSC/SwitcherPanelAppDelegate.mm you may just want to look at the source.  The only changes I made to the existing Monitor classes was removing that repeating code and changing where it inherited from, and after testing I confirmed that they all still work as expected with no compiler warnings.

### Testing

I tested this on an ATEM Studio Switcher but only with one USK, so it may be worth testing on a larger switch with more than one USK to make sure the feedback works correctly and is routed to the correct key.