### PR TITLE
Bug Fix - When a key is set for next transition, don't deselect other keys

### DIFF
--- a/atemOSC/SwitcherPanelAppDelegate.mm
+++ b/atemOSC/SwitcherPanelAppDelegate.mm
@@ -394,19 +394,24 @@ public:
             }
 		} else if ([[address objectAtIndex:1] isEqualToString:@"atem"] &&
                    [[address objectAtIndex:2] isEqualToString:@"nextusk"]) {
-            switch ([[address objectAtIndex:3] intValue]) {
-                case 0:
-                    switcherTransitionParameters->SetNextTransitionSelection(bmdSwitcherTransitionSelectionBackground); break;
-                case 1:
-                    switcherTransitionParameters->SetNextTransitionSelection(bmdSwitcherTransitionSelectionKey1); break;
-                case 2:
-                    switcherTransitionParameters->SetNextTransitionSelection(bmdSwitcherTransitionSelectionKey2); break;
-                case 3:
-                    switcherTransitionParameters->SetNextTransitionSelection(bmdSwitcherTransitionSelectionKey3); break;
-                case 4:
-                    switcherTransitionParameters->SetNextTransitionSelection(bmdSwitcherTransitionSelectionKey4); break;
-                default:
-                    break;
+            int t = [[address objectAtIndex:3] intValue];
+            bool value = [[m value] floatValue] != 0.0;
+            
+            uint32_t currentTransitionSelection;
+            switcherTransitionParameters->GetNextTransitionSelection(&currentTransitionSelection);
+            
+            uint32_t transitionSelections[5] = { bmdSwitcherTransitionSelectionBackground, bmdSwitcherTransitionSelectionKey1, bmdSwitcherTransitionSelectionKey2, bmdSwitcherTransitionSelectionKey3, bmdSwitcherTransitionSelectionKey4 };
+            uint32_t requestedTransitionSelection = transitionSelections[t];
+            
+            if (value) {
+                switcherTransitionParameters->SetNextTransitionSelection(currentTransitionSelection | requestedTransitionSelection);
+            } else {
+                
+                // If we are attempting to deselect the only bit set, then default to setting TransitionSelectionBackground
+                if ((currentTransitionSelection & ~requestedTransitionSelection) == 0)
+                    switcherTransitionParameters->SetNextTransitionSelection(bmdSwitcherTransitionSelectionBackground);
+                else
+                    switcherTransitionParameters->SetNextTransitionSelection(currentTransitionSelection & ~requestedTransitionSelection);
             }
         } else if ([[address objectAtIndex:1] isEqualToString:@"atem"] &&
                    [[address objectAtIndex:2] isEqualToString:@"usk"]) {


### PR DESCRIPTION
Currently, the /atem/nextusk command behavior has an overflow effect where if I set one USK to ON, it deselects all of the other USK's that might have been tied to the next transition.  This seems incorrect, as I should be able to tie and untie each USK independently of the other ones.

The more important side effect is when /atem/nextusk/1 1 is sent, the BKGN is deselected, so that /atem/nextusk/1 0 will not actually deselect USK 1 because there needs to be at least on USK selected (should be background).

This PR uses bit masks to turn on and off each USK independently of the others, which I believe is the correct behavior.

This has been tested on an ATEM Production Studio with One USK.