### PR TITLE
Resolves #48 - Allows changing switcher, but adds confirmation alert

### DIFF
--- a/atemOSC/SettingsWindow.mm
+++ b/atemOSC/SettingsWindow.mm
@@ -59,7 +59,36 @@
 	if (![[mAddressTextField stringValue] isEqualToString:@""])
 	{
 		if ([self isValidIPAddress:[mAddressTextField stringValue]])
-			[prefs setObject:[mAddressTextField stringValue] forKey:@"atem"];
+		{
+			// If we are already connected, and they want to connect to a different one, we need to make sure they didn't just accidently bump the keyboard
+			NSTextField* textField = (NSTextField *)[aNotification object];
+			if (textField == mAddressTextField && [appDel isConnectedToATEM] && ![[textField stringValue] isEqualToString:[prefs stringForKey:@"atem"]])
+			{
+				NSAlert *alert = [[NSAlert alloc] init];
+				[alert setMessageText:@"Switcher Currently Connected"];
+				[alert setInformativeText:[NSString stringWithFormat: @"Are you sure you want to disconnect from %@ and attempt to connect to %@?", [prefs stringForKey:@"atem"], [textField stringValue]]];
+				[alert addButtonWithTitle:@"Yes (Connect to New)"];
+				[alert addButtonWithTitle:@"No (Stay Connected)"];
+				[alert beginSheetModalForWindow:[(AppDelegate *)[[NSApplication sharedApplication] delegate] window] completionHandler:^(NSInteger returnCode)
+				 {
+					 if ( returnCode == NSAlertFirstButtonReturn )
+					 {
+						 [prefs setObject:[mAddressTextField stringValue] forKey:@"atem"];
+						 [appDel switcherDisconnected];
+						 [appDel connectBMD];
+					 }
+					 else if ( returnCode == NSAlertSecondButtonReturn )
+					 {
+						 NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
+						 [mAddressTextField setStringValue:[prefs stringForKey:@"atem"]];
+					 }
+				 }];
+			}
+			else
+			{
+				[prefs setObject:[mAddressTextField stringValue] forKey:@"atem"];
+			}
+		}
 		else
 		{
 			validInput = NO;

--- a/atemOSC/SettingsWindow.mm
+++ b/atemOSC/SettingsWindow.mm
@@ -14,8 +14,6 @@
 {
 	NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
 	[mAddressTextField setStringValue:[prefs stringForKey:@"atem"]];
-	NSLog(@"Value: %@", [prefs stringForKey:@"atem"]);
-	
 	[mOutgoingPortTextField setIntValue:[prefs integerForKey:@"outgoing"]];
 	[mIncomingPortTextField setIntValue:[prefs integerForKey:@"incoming"]];
 	[mOscDeviceTextField setStringValue:[prefs objectForKey:@"oscdevice"]];
@@ -41,8 +39,9 @@
 	AppDelegate* appDel = (AppDelegate *) [[NSApplication sharedApplication] delegate];
 	BOOL validInput = YES;
 	NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
+	NSTextField* textField = (NSTextField *)[aNotification object];
 	
-	if (![[mOscDeviceTextField stringValue] isEqualToString:@""])
+	if (textField == mOscDeviceTextField)
 	{
 		if ([self isValidIPAddress:[mOscDeviceTextField stringValue]])
 			[prefs setObject:[mOscDeviceTextField stringValue] forKey:@"oscdevice"];
@@ -56,13 +55,12 @@
 		}
 	}
 	
-	if (![[mAddressTextField stringValue] isEqualToString:@""])
+	if (textField == mAddressTextField)
 	{
 		if ([self isValidIPAddress:[mAddressTextField stringValue]])
 		{
 			// If we are already connected, and they want to connect to a different one, we need to make sure they didn't just accidently bump the keyboard
-			NSTextField* textField = (NSTextField *)[aNotification object];
-			if (textField == mAddressTextField && [appDel isConnectedToATEM] && ![[textField stringValue] isEqualToString:[prefs stringForKey:@"atem"]])
+			if ([appDel isConnectedToATEM] && ![[textField stringValue] isEqualToString:[prefs stringForKey:@"atem"]])
 			{
 				NSAlert *alert = [[NSAlert alloc] init];
 				[alert setMessageText:@"Switcher Currently Connected"];
@@ -79,7 +77,6 @@
 					 }
 					 else if ( returnCode == NSAlertSecondButtonReturn )
 					 {
-						 NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
 						 [mAddressTextField setStringValue:[prefs stringForKey:@"atem"]];
 					 }
 				 }];
@@ -89,13 +86,16 @@
 				[prefs setObject:[mAddressTextField stringValue] forKey:@"atem"];
 			}
 		}
-		else
+		else if ([appDel isConnectedToATEM] || ![[mAddressTextField stringValue] isEqualToString:@""])
 		{
 			validInput = NO;
 			NSAlert *alert = [[NSAlert alloc] init];
 			[alert setMessageText:@"Invalid IP Adress"];
 			[alert setInformativeText:@"Please enter a valid IP Address for 'Switcher IP Adress'"];
 			[alert beginSheetModalForWindow:[(AppDelegate *)[[NSApplication sharedApplication] delegate] window] completionHandler:nil];
+			
+			if ([appDel isConnectedToATEM])
+				[mAddressTextField setStringValue:[prefs stringForKey:@"atem"]];
 		}
 	}
 	

--- a/atemOSC/SettingsWindow.mm
+++ b/atemOSC/SettingsWindow.mm
@@ -50,7 +50,7 @@
 			validInput = NO;
 			NSAlert *alert = [[NSAlert alloc] init];
 			[alert setMessageText:@"Invalid IP Adress"];
-			[alert setInformativeText:@"Please enter a valid IP Address for 'OSC Out IP Adress'"];
+			[alert setInformativeText:@"Please enter a valid IPv4 Address for 'OSC Out IP Address'"];
 			[alert beginSheetModalForWindow:[(AppDelegate *)[[NSApplication sharedApplication] delegate] window] completionHandler:nil];
 		}
 	}
@@ -73,7 +73,6 @@
 					 {
 						 [prefs setObject:[mAddressTextField stringValue] forKey:@"atem"];
 						 [appDel switcherDisconnected];
-						 [appDel connectBMD];
 					 }
 					 else if ( returnCode == NSAlertSecondButtonReturn )
 					 {
@@ -91,7 +90,7 @@
 			validInput = NO;
 			NSAlert *alert = [[NSAlert alloc] init];
 			[alert setMessageText:@"Invalid IP Adress"];
-			[alert setInformativeText:@"Please enter a valid IP Address for 'Switcher IP Adress'"];
+			[alert setInformativeText:@"Please enter a valid IPv4 Address for 'Switcher IP Address'"];
 			[alert beginSheetModalForWindow:[(AppDelegate *)[[NSApplication sharedApplication] delegate] window] completionHandler:nil];
 			
 			if ([appDel isConnectedToATEM])


### PR DESCRIPTION
This addresses the issue that you cannot change the switcher IP without restarting atemOSC.  This allows the IP to be changed, but prompts for confirmation before disconnecting from the current switcher.