### PR TITLE
Issue #91 - Not showing up as OSC destination if using default port

### DIFF
--- a/atemOSC/AppDelegate.mm
+++ b/atemOSC/AppDelegate.mm
@@ -105,18 +105,32 @@
 		manager = [[OSCManager alloc] init];
 		
 		NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
-		[self portChanged:[prefs integerForKey:@"incoming"] out:[prefs integerForKey:@"outgoing"] ip:[prefs stringForKey:@"oscdevice"]];
+
+		int incomingPort = 3333, outgoingPort = 4444;
+		NSString *outIpStr = nil;
+		if ([prefs integerForKey:@"outgoing"])
+			outgoingPort = (int) [prefs integerForKey:@"outgoing"];
+		if ([prefs integerForKey:@"incoming"])
+			incomingPort = (int) [prefs integerForKey:@"incoming"];
+		if ([prefs stringForKey:@"oscdevice"])
+			outIpStr = [prefs stringForKey:@"oscdevice"];
+
+		[self portChanged:incomingPort out:outgoingPort ip:outIpStr];
 	}
 }
 
 - (void)portChanged:(int)inPortValue out:(int)outPortValue ip:(NSString *)outIpStr
 {
 	[manager removeInput:inPort];
-	[manager removeOutput:outPort];
-	
-	outPort = [manager createNewOutputToAddress:outIpStr atPort:outPortValue withLabel:@"atemOSC"];
+
+	if (outIpStr != nil)
+	{
+		[manager removeOutput:outPort];
+		outPort = [manager createNewOutputToAddress:outIpStr atPort:outPortValue withLabel:@"atemOSC"];
+	}
+
 	inPort = [manager createNewInputForPort:inPortValue withLabel:@"atemOSC"];
-	
+
 	[manager setDelegate:mOscReceiver];
 }
 


### PR DESCRIPTION
This fixes an issue where atemOSC would not appear as a host in TouchOSC if there was no preference stored for incoming and outgoing port (a.k.a. if the default ports were not changed).