### PR TITLE
Input Name Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Feedback: Enabled for all values
 
 Note: The actual numbers vary greatly from device to device, be sure to check the in-app address menu
 
+Note: You can fetch the names of each input by sending the `/atem/send-status` command (detailed later), this will return the short names of each input to `/atem/input/$i/short-name` and the long names to `/atem/input/$i/long-name`. After the initial fetch, you will also recieve updates when the short or long name is changed in ATEM Software Control.
 
 ### Transition Control
 

--- a/atemOSC/AppDelegate.h
+++ b/atemOSC/AppDelegate.h
@@ -60,6 +60,8 @@
 
 @property (readonly)       IBMDSwitcher*				        	mSwitcher;
 @property (readonly)       std::vector<IBMDSwitcherSuperSourceBox*> mSuperSourceBoxes;
+@property (readonly)       std::map<BMDSwitcherInputId, IBMDSwitcherInput*> mInputs;
+@property (readonly)       std::map<BMDSwitcherInputId, InputMonitor*> mInputMonitors;
 @property (readonly)       std::vector<IBMDSwitcherInputAux*>       mSwitcherInputAuxList;
 @property (readonly)       IBMDSwitcherStills*                      mStills;
 @property (readonly)       IBMDSwitcherInputSuperSource*            mSuperSource;

--- a/atemOSC/AppDelegate.mm
+++ b/atemOSC/AppDelegate.mm
@@ -539,6 +539,12 @@ finish:
 		it.second->Release();
 	}
 	
+	for (auto const& it : mInputs)
+	{
+		it.second->RemoveCallback(mInputMonitors.at(it.first));
+		it.second->Release();
+	}
+	
 	if (mAudioMixer)
 	{
 		mAudioMixer->RemoveCallback(mAudioMixerMonitor);

--- a/atemOSC/AppDelegate.mm
+++ b/atemOSC/AppDelegate.mm
@@ -46,6 +46,8 @@
 @synthesize mSuperSource;
 @synthesize mMacroControl;
 @synthesize mSuperSourceBoxes;
+@synthesize mInputs;
+@synthesize mInputMonitors;
 @synthesize mSwitcherInputAuxList;
 @synthesize mAudioInputs;
 @synthesize mAudioInputMonitors;
@@ -271,6 +273,14 @@
 		// For every input, install a callback to monitor property changes on the input
 		while (S_OK == inputIterator->Next(&input))
 		{
+			BMDSwitcherInputId inputId;
+			input->GetInputId(&inputId);
+			mInputs.insert(std::make_pair(inputId, input));
+			InputMonitor *monitor = new InputMonitor(self, inputId);
+			input->AddCallback(monitor);
+			mMonitors.push_back(monitor);
+			mInputMonitors.insert(std::make_pair(inputId, monitor));
+			
 			IBMDSwitcherInputAux* auxObj;
 			result = input->QueryInterface(IID_IBMDSwitcherInputAux, (void**)&auxObj);
 			if (SUCCEEDED(result))

--- a/atemOSC/FeedbackMonitors.h
+++ b/atemOSC/FeedbackMonitors.h
@@ -43,9 +43,6 @@ public:
 	HRESULT PropertyChanged(BMDSwitcherMixEffectBlockPropertyId propertyId);
 	bool moveSliderDownwards() const;
 	bool mMoveSliderDownwards = false;
-	void updateProgramButtonSelection() const;
-	void updatePreviewButtonSelection() const;
-	void updateInTransitionState();
 	void updateSliderPosition();
 	float sendStatus() const;
 	
@@ -53,7 +50,26 @@ protected:
 	virtual ~MixEffectBlockMonitor() { }
 	
 private:
+	void updateProgramButtonSelection() const;
+	void updatePreviewButtonSelection() const;
+	void updateInTransitionState();
 	bool mCurrentTransitionReachedHalfway_ = false;
+};
+
+class InputMonitor : public GenericMonitor<IBMDSwitcherInputCallback>, public SendStatusInterface
+{
+public:
+	InputMonitor(void *delegate, BMDSwitcherInputId inputId) : GenericMonitor(delegate), inputId_(inputId) { }
+	HRESULT Notify(BMDSwitcherInputEventType eventType);
+	float sendStatus() const;
+	
+protected:
+	virtual ~InputMonitor() { }
+	
+private:
+	void updateShortName() const;
+	void updateLongName() const;
+	BMDSwitcherInputId  inputId_;
 };
 
 class DownstreamKeyerMonitor : public GenericMonitor<IBMDSwitcherDownstreamKeyCallback>, public SendStatusInterface


### PR DESCRIPTION
This sends the short- and long-name of each input out as feedback on a send-status command or on change.