### PR TITLE
Adding Preview Transition ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ Note: The actual numbers vary greatly from device to device, be sure to check th
 
  - **T-bar** `/atem/transition/bar <0-1>`
  - **Cut** `/atem/transition/cut`
- - **auto** `/atem/transition/auto`
- - **fade-to-black** `/atem/transition/ftb`
+ - **Auto** `/atem/transition/auto`
+ - **Fade to Black** `/atem/transition/ftb`
+ - **Preview Transition** `/atem/transition/preview <0|1>`
 
 To set the transition type of the Auto transition:
 

--- a/atemOSC/FeedbackMonitors.h
+++ b/atemOSC/FeedbackMonitors.h
@@ -47,6 +47,7 @@ public:
 	void updatePreviewButtonSelection() const;
 	void updateInTransitionState();
 	void updateSliderPosition();
+	void updatePreviewTransitionEnabled() const;
 	float sendStatus() const;
 	
 protected:

--- a/atemOSC/FeedbackMonitors.mm
+++ b/atemOSC/FeedbackMonitors.mm
@@ -62,6 +62,9 @@ HRESULT MixEffectBlockMonitor::PropertyChanged(BMDSwitcherMixEffectBlockProperty
 		case bmdSwitcherMixEffectBlockPropertyIdTransitionPosition:
 			updateSliderPosition();
 			break;
+		case bmdSwitcherMixEffectBlockPropertyIdPreviewTransition:
+			updatePreviewTransitionEnabled();
+			break;
 		case bmdSwitcherMixEffectBlockPropertyIdTransitionFramesRemaining:
 			break;
 		case bmdSwitcherMixEffectBlockPropertyIdFadeToBlackFramesRemaining:
@@ -131,6 +134,16 @@ void MixEffectBlockMonitor::updateSliderPosition()
 	[static_cast<AppDelegate *>(appDel).outPort sendThisMessage:newMsg];
 }
 
+void MixEffectBlockMonitor::updatePreviewTransitionEnabled() const
+{
+	bool position;
+	static_cast<AppDelegate *>(appDel).mMixEffectBlock->GetFlag(bmdSwitcherMixEffectBlockPropertyIdPreviewTransition, &position);
+	
+	OSCMessage *newMsg = [OSCMessage createWithAddress:@"/atem/transition/preview"];
+	[newMsg addFloat: position ? 1.0 : 0.0];
+	[static_cast<AppDelegate *>(appDel).outPort sendThisMessage:newMsg];
+}
+
 float MixEffectBlockMonitor::sendStatus() const
 {
 	// Sending both program and preview at the same time causes a race condition, TouchOSC can't handle
@@ -141,6 +154,8 @@ float MixEffectBlockMonitor::sendStatus() const
 	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.15 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
 		updateProgramButtonSelection();
 	});
+	
+	updatePreviewTransitionEnabled();
 	
 	double position;
 	static_cast<AppDelegate *>(appDel).mMixEffectBlock->GetFloat(bmdSwitcherMixEffectBlockPropertyIdTransitionPosition, &position);

--- a/atemOSC/OSCAddressPanel.mm
+++ b/atemOSC/OSCAddressPanel.mm
@@ -40,6 +40,7 @@
 	[self addEntry:@"Cut" forAddress:@"/atem/transition/cut" toString:helpString];
 	[self addEntry:@"Auto-Cut" forAddress:@"/atem/transition/auto" toString:helpString];
 	[self addEntry:@"Fade-to-black" forAddress:@"/atem/transition/ftb" toString:helpString];
+	[self addEntry:@"Preview Transition" forAddress:@"/atem/transition/preview" toString:helpString];
 
 	[self addHeader:@"Transition type" toString:helpString];
 	[self addEntry:@"Set to Mix" forAddress:@"/atem/transition/set-type/mix" toString:helpString];

--- a/atemOSC/OSCReceiver.mm
+++ b/atemOSC/OSCReceiver.mm
@@ -44,6 +44,9 @@
 				else if ([[address objectAtIndex:3] isEqualToString:@"ftb"])
 					[appDel mMixEffectBlock]->PerformFadeToBlack();
 				
+				else if ([[address objectAtIndex:3] isEqualToString:@"preview"])
+					[appDel mMixEffectBlock]->SetFlag(bmdSwitcherMixEffectBlockPropertyIdPreviewTransition, (int)[m calculateFloatValue]);
+				
 				else if ([[address objectAtIndex:3] isEqualToString:@"set-type"])
 				{
 					


### PR DESCRIPTION
This enables the `/atem/transition/preview <0|1>` endpoint to enable/disable transition preview (corresponds 1-to-1 with "PREV TRANS" button in ATEM Software Control).